### PR TITLE
add option to not redraw the whole calendar after selecting a date

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -496,6 +496,14 @@
                     </ul>
                     <p>Show calendar inline. If <code>true</code> and <code>parentEl</code> is not provided then will use <code>parentNode</code> of field.</p>
 
+
+                    <p class="lead"><code>dontRedrawAfterSelect</code></p>
+                    <ul>
+                        <li>Type: <code>Boolean</code></li>
+                        <li>Default: <code>false</code></li>
+                    </ul>
+                    <p>Don't redraw the calendar after a selection is made. If <code>true</code>, the state of the calendar will have to be manually updated after a date is selected.</p>
+
                     <p class="lead"><code>dropdowns</code></p>
                     <ul>
                         <li>Type: <code>Object|Boolean</code></li>
@@ -519,7 +527,7 @@
                     <p class="lead"><code>locale</code></p>
                     <ul>
                         <li>Type: <code>Object</code></li>
-                        <li>Default: 
+                        <li>Default:
                             <code><br>
                             { <br>
                             &nbsp;&nbsp;buttons: { <br>

--- a/lightpick.js
+++ b/lightpick.js
@@ -54,6 +54,7 @@
         tooltipNights: false,
         orientation: 'auto',
         disableWeekends: false,
+        dontRedrawAfterSelect: false,
         inline: false,
         dropdowns: {
             years: {
@@ -574,7 +575,7 @@
                                 self.hide();
                             }, 100);
                         }
-                        else if (!opts.singleDate || opts.inline) {
+                        else if (!opts.dontRedrawAfterSelect && (!opts.singleDate || opts.inline)) {
                             updateDates(self.el, opts);
                         }
                     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightpick",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Javascript date range picker - lightweight, no jQuery",
   "main": "lightpick.js",
   "scripts": {


### PR DESCRIPTION
you'll have to maintain the state of the classes for each day yourself – mostly just removing `is-start-date` from any previously selected date